### PR TITLE
Manual Implement GPG Signing for Terraform Provider Releases

### DIFF
--- a/.github/workflows/release-checks.yml
+++ b/.github/workflows/release-checks.yml
@@ -44,7 +44,6 @@ jobs:
   publish:
     needs: build-and-test
     runs-on: ubuntu-latest
-
     steps:
 
       - name: Checkout Repository
@@ -56,13 +55,21 @@ jobs:
           go-version: '1.19'
           stable: true
 
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v6
+        id: import_gpg
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.PASSPHRASE }}
+
       - name: Determine release tag
         id: release_tag
         run: echo "::set-output name=tag::v0.1.0-${{ github.sha }}"
       
-      - name: Build Release Binary
+      - name: Build and sign Release Binary
         run: |
           GOOS=linux GOARCH=amd64 go build -o terraform-provider-kong_${{ steps.release_tag.outputs.tag }}
+          gpg --batch --yes -a -b -o terraform-provider-kong_${{ steps.release_tag.outputs.tag }}.sig terraform-provider-kong_${{ steps.release_tag.outputs.tag }}
 
       - name: Create Release
         id: create_release
@@ -75,12 +82,22 @@ jobs:
           draft: false
           prerelease: false
 
-      - name: Upload Release Asset
+      - name: Upload Release Asset Binary
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./terraform-provider-kong_${{ steps.release_tag.outputs.tag }}
+          asset_name: terraform-provider-kong_${{ steps.release_tag.outputs.tag }}
+          asset_content_type: application/octet-stream
+
+      - name: Upload Release Signature Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./terraform-provider-kong_${{ steps.release_tag.outputs.tag }}.sig
           asset_name: terraform-provider-kong_${{ steps.release_tag.outputs.tag }}
           asset_content_type: application/octet-stream


### PR DESCRIPTION
This PR introduces GPG signing for our Terraform provider releases, enhancing the security and verifiability of our binaries. By incorporating cryptographic signatures, we ensure that users can verify the integrity and origin of the released binaries, thus safeguarding against unauthorized modifications.

Changes made:
- Integrated the GPG key import process into the GitHub Actions release workflow.
- Modified the build step to not only build but also sign the release binary with the GPG key.
- Added a new step to upload the GPG signature file as an additional asset to the GitHub release.

The addition of these steps ensures that every release going forward will include a `.sig` file that can be used to verify the release binary using GPG. This change is a part of ongoing efforts to increase the security of our development and release processes.

Please review the changes and provide your feedback.